### PR TITLE
Fix bug where argument templates would get rendered into the exec con…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The process should shut down cleanly in response to SIGTERMs.
   <tr><td>hostname</td><td>required</td><td>foo.bar.com</td><td>The name of the host to be provisioned, as it will identify itself to puppet.</td></tr>
   <tr><td>tasks</td><td>required</td><td>cert,environment</td><td>Comma-separated list of provisioning operations to perform. Valid operations are the `Name`s defined in the `GenericExecTasks` configuration section, plus the special built-in task name `cert` to cause client certificate signing.</td></tr>
   <tr><td>waits</td><td>optional</td><td>environment</td><td>Comma-separated list of provisioning operations to wait for before the response is sent back. If you need to know the outcome of a provisioning operation, add it to this list and its results will be included in the response.</td></tr>  
-  <tr><td>cert-revoke</td><td>optional</td><td>true</td><td>If set, any existing certificates for the same hostname will be reovked to enable successful signing of a new CSR for this hostname.</td></tr>
+  <tr><td>cert-revoke</td><td>optional</td><td>true</td><td>If set, any existing certificates for the same hostname will be revoked to enable successful signing of a new CSR for this hostname.</td></tr>
 </table>
 
 Requested tasks are assumed to be independent of each other and are run concurrently. If you need

--- a/SimplePuppetProvisioner.go
+++ b/SimplePuppetProvisioner.go
@@ -48,7 +48,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	execManager := genericexec.NewGenericExecManager(makeExecTaskConfigsMap(&appConfig), appConfig.PuppetConfig, appConfig.Log, notifier.Notify)
+	execConfigMap := makeExecTaskConfigsMap(&appConfig)
+	execManager := genericexec.NewGenericExecManager(execConfigMap, appConfig.PuppetConfig, appConfig.Log, notifier.Notify)
 
 	server := lib.NewHttpServer(appConfig, notifier, certSigner, execManager)
 
@@ -82,7 +83,10 @@ func main() {
 }
 
 func makeExecTaskConfigsMap(config *lib.AppConfig) map[string]genericexec.GenericExecConfig {
-	theMap := map[string]genericexec.GenericExecConfig{}
-	// TODO
-	return theMap
+	execTaskDefns := config.GenericExecTasks
+	execTaskConfigsByName := make(map[string]genericexec.GenericExecConfig, len(execTaskDefns))
+	for _, configuredTask := range execTaskDefns {
+		execTaskConfigsByName[configuredTask.Name] = *configuredTask
+	}
+	return execTaskConfigsByName
 }

--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -12,11 +12,10 @@ import (
 )
 
 type ProvisionHttpHandler struct {
-	appConfig             *AppConfig
-	notifier              *Notifications
-	certSigner            *certsign.CertSigner
-	execManager           *genericexec.GenericExecManager
-	execTaskConfigsByName map[string]genericexec.GenericExecConfig
+	appConfig   *AppConfig
+	notifier    *Notifications
+	certSigner  *certsign.CertSigner
+	execManager *genericexec.GenericExecManager
 }
 
 type TaskResult struct {
@@ -27,13 +26,6 @@ type TaskResult struct {
 
 func NewProvisionHttpHandler(appConfig *AppConfig, notifier *Notifications, certSigner *certsign.CertSigner, execManager *genericexec.GenericExecManager) *ProvisionHttpHandler {
 	handler := ProvisionHttpHandler{appConfig: appConfig, notifier: notifier, certSigner: certSigner, execManager: execManager}
-
-	execTaskDefns := handler.appConfig.GenericExecTasks
-	execTaskConfigsByName := make(map[string]genericexec.GenericExecConfig, len(execTaskDefns))
-	for _, configuredTask := range execTaskDefns {
-		execTaskConfigsByName[configuredTask.Name] = *configuredTask
-	}
-	handler.execTaskConfigsByName = execTaskConfigsByName
 
 	return &handler
 }
@@ -115,7 +107,7 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 
 	// Process generic exec tasks
 	for _, requestTask := range tasks {
-		if _, isConfigured := ctx.execTaskConfigsByName[requestTask]; isConfigured {
+		if ctx.execManager.IsTaskConfigured(requestTask) {
 			ctx.execManager.RunTask(requestTask, &request.Form)
 		} else {
 			responseWrapper[requestTask] = TaskResult{

--- a/scripts/set-environment.sh
+++ b/scripts/set-environment.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This script accepts as arguments a hostname and associated environment. It commits this as a file readable by
+# the simple ENC https://github.com/Zetten/puppet-hiera-enc.
+
+set -e
+
+LOCAL_CLONE=~/node-environments
+HOSTNAME=$1
+ENVIRONMENT=$2
+
+if [ ! -d $LOCAL_CLONE/.git ]; then
+  >&2 echo "Local git clone was not found at $LOCAL_CLONE; you must manually clone to this location once."
+  exit 1
+fi
+
+if [ -z "$HOSTNAME" -o -z "$ENVIRONMENT" ]; then
+  >&2 echo "Invalid input to set-environment.sh: A nonempty hostname and environment are required."
+  exit 1
+fi
+
+cd $LOCAL_CLONE
+
+git pull
+echo "environment: $ENVIRONMENT" > "$HOSTNAME.yml"
+git add "$HOSTNAME.yml"
+git commit -m "environment: $ENVIRONMENT (automated commit for $HOSTNAME)"
+git push
+
+echo "Done."


### PR DESCRIPTION
…figs and rendered versions reused for subsequent commands, add test for GenericExecManager reuse. Fix bug with cmdFactory in code path that could not be covered in test. Add an example bash script in scripts/ corresponding to the "environment" task in the reference spp.conf.yml