### PR TITLE
Set wait chan to nil once closed

### DIFF
--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -127,9 +127,9 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 	waitsComplete := 0
 	for waitsComplete < len(waitResultChans) {
 		chosen, rvalue, ok := reflect.Select(waitResultChans)
-		if ! ok {
+		if !ok {
 			waitResultChans[chosen].Chan = reflect.ValueOf(nil)
-			continue;
+			continue
 		}
 		switch value := rvalue.Interface().(type) {
 		case certsign.SigningResult:

--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -126,7 +126,11 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 	// Wait for all operations we need to wait on
 	waitsComplete := 0
 	for waitsComplete < len(waitResultChans) {
-		_, rvalue, _ := reflect.Select(waitResultChans)
+		chosen, rvalue, ok := reflect.Select(waitResultChans)
+		if ! ok {
+			waitResultChans[chosen].Chan = reflect.ValueOf(nil)
+			continue;
+		}
 		switch value := rvalue.Interface().(type) {
 		case certsign.SigningResult:
 			responseWrapper["cert"] = TaskResult{


### PR DESCRIPTION
I found a couple examples online using the 'set chan to nil' method of waiting on several channels that close. Seems to work correctly.

https://stackoverflow.com/questions/13666253/breaking-out-of-a-select-statement-when-all-channels-are-closed
https://github.com/eapache/channels/blob/47238d5aae8c0fefd518ef2bee46290909cf8263/channels.go#L99