### PR TITLE
Cert revoke task

### DIFF
--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -127,9 +127,9 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 	waitsComplete := 0
 	for waitsComplete < len(waitResultChans) {
 		chosen, rvalue, ok := reflect.Select(waitResultChans)
-		if ! ok {
+		if !ok {
 			waitResultChans[chosen].Chan = reflect.ValueOf(nil)
-			continue;
+			continue
 		}
 		switch value := rvalue.Interface().(type) {
 		case certsign.SigningResult:

--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -82,27 +82,63 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 	// Set up slice for response channels we've been asked to wait on.
 	waitResultChans := []reflect.SelectCase{}
 
-	if i := tasks.Search("cert"); i < len(tasks) && tasks[i] == "cert" {
-		var certRevoke = false
-		if request.Form.Get("cert-revoke") != "" && request.Form.Get("cert-revoke") != "false" {
-			certRevoke = true
-		}
+	// Cert-related tasks
+	var certSign, certRevoke = false, false
 
-		signingResultChan := ctx.certSigner.Sign(hostname, certRevoke)
-		if i := waits.Search("cert"); i < len(waits) && waits[i] == "cert" {
+	for i := len(tasks) - 1; i >= 0; i-- {
+		if tasks[i] == "cert" || tasks[i] == "cert-sign" {
+			certSign = true
+			// Remove the cert task from the remaining tasks list.
+			tasks = append(tasks[0:i], tasks[i+1:]...)
+		} else if tasks[i] == "cert-revoke" {
+			certRevoke = true
+			// Remove the cert task from the remaining tasks list.
+			tasks = append(tasks[0:i], tasks[i+1:]...)
+		}
+	}
+
+	if request.Form.Get("cert-revoke") != "" && request.Form.Get("cert-revoke") != "false" {
+		certRevoke = true
+	}
+
+	if certRevoke {
+		cleaningResultChan := ctx.certSigner.Clean(hostname)
+		if i := waits.Search("cert-revoke"); i < len(waits) && waits[i] == "cert-revoke" {
+			waitResultChans = append(waitResultChans, reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(cleaningResultChan),
+			})
+		} else {
+			responseWrapper["cert-revoke"] = TaskResult{
+				Complete: false,
+				Success:  true,
+				Message:  "Certificate cleaning operation was queued. To see the results in this response, include \"cert-revoke\" in the waits list.",
+			}
+		}
+	}
+
+	if certSign {
+		signingResultChan := ctx.certSigner.Sign(hostname, false)
+		shouldWait := false
+		for _, wait := range waits {
+			if wait == "cert" || wait == "cert-sign" {
+				shouldWait = true
+				break
+			}
+		}
+		if shouldWait {
 			waitResultChans = append(waitResultChans, reflect.SelectCase{
 				Dir:  reflect.SelectRecv,
 				Chan: reflect.ValueOf(signingResultChan),
 			})
 		} else {
-			responseWrapper["cert"] = TaskResult{
+			responseWrapper["cert-sign"] = TaskResult{
 				Complete: false,
 				Success:  true,
-				Message:  "Certificate signing operation was queued. To see the results in this response, include \"cert\" in the waits list.",
+				Message:  "Certificate signing operation was queued. To see the results in this response, include \"cert-sign\" in the waits list.",
 			}
 		}
-		// Remove the cert task from the remaining tasks list.
-		tasks = append(tasks[0:i], tasks[i+1:]...)
+
 	}
 
 	// Process generic exec tasks
@@ -133,7 +169,7 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 		}
 		switch value := rvalue.Interface().(type) {
 		case certsign.SigningResult:
-			responseWrapper["cert"] = TaskResult{
+			responseWrapper[fmt.Sprintf("cert-%s", value.Action)] = TaskResult{
 				Complete: true,
 				Success:  value.Success,
 				Message:  value.Message,

--- a/lib/ProvisionHttpHandler.go
+++ b/lib/ProvisionHttpHandler.go
@@ -126,7 +126,11 @@ func (ctx ProvisionHttpHandler) ServeHTTP(response http.ResponseWriter, request 
 	// Wait for all operations we need to wait on
 	waitsComplete := 0
 	for waitsComplete < len(waitResultChans) {
-		_, rvalue, _ := reflect.Select(waitResultChans)
+		chosen, rvalue, ok := reflect.Select(waitResultChans)
+		if ! ok {
+			waitResultChans[chosen].Chan = reflect.ValueOf(nil)
+			continue;
+		}
 		switch value := rvalue.Interface().(type) {
 		case certsign.SigningResult:
 			responseWrapper["cert"] = TaskResult{

--- a/lib/certsign/CertSigner.go
+++ b/lib/certsign/CertSigner.go
@@ -124,7 +124,6 @@ func (ctx *CertSigner) Shutdown() {
 
 func (ctx *CertSigner) signQueueWorker() {
 	for message, opened := <-ctx.signQueue; opened; message, opened = <-ctx.signQueue {
-		ctx.log.Printf("signQueueWorker: %#v\n", message)
 		certExists := false
 		existingCertPath := fmt.Sprintf("%s/%s.pem", ctx.puppetConfig.SignedCertDir, message.certSubject)
 		fh, _ := ctx.openFileFunc(existingCertPath, os.O_RDONLY, 0660)


### PR DESCRIPTION
An initial pass at adding a cert-revoke task. You can now specify cert-revoke as a task or wait and the existing cert-revoke=true parameter still works too. Also fixes a race condition on shutdown that caused a panic if the CSR watcher tried to write to a closed channel.

Should also close #12 