### PR TITLE
Add GChat webhook support, separate provision auth, and web-based log

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ object with the following values:
   <tr><td>Message</td><td>string</td><td>An optional message with details about the task's outcome.</td></tr>
 </table>
 
+### /log
+#### Request
+**Method: GET**
+#### Response
+**Content_Type: text/plain
+Prints the last 50 log messages. Can be used in notification messages to provide a URL to additional details on errors.
+
 ## Configuration
 ### File formats and location
 The service will look for its configuration file in the working directory and in

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ object with the following values:
 #### Request
 **Method: GET**
 #### Response
-**Content_Type: text/plain
+**Content-Type: text/plain**
 Prints the last 50 log messages. Can be used in notification messages to provide a URL to additional details on errors.
 
 ## Configuration

--- a/SimplePuppetProvisioner.go
+++ b/SimplePuppetProvisioner.go
@@ -84,7 +84,6 @@ func main() {
 	appConfig.Log.Println("Certificate signing manager shutdown.")
 
 	appConfig.Log.Println("Process will now exit.")
-	appConfig.FlushLog()
 }
 
 func makeExecTaskConfigsMap(config *lib.AppConfig) map[string]genericexec.GenericExecConfig {

--- a/TestFixtures/configs/ProvisionAuth.conf.yml
+++ b/TestFixtures/configs/ProvisionAuth.conf.yml
@@ -1,0 +1,6 @@
+---
+BindAddress: 127.0.0.1:8240
+PuppetExecutable: ../TestFixtures/fakepuppet.sh
+ProvisionAuth:
+  Type: basic
+  DbFile: ../TestFixtures/test.htpasswd

--- a/lib/AppConfig.go
+++ b/lib/AppConfig.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"bufio"
+	"container/ring"
 	"github.com/go-chat-bot/bot/irc"
 	"github.com/mbaynton/SimplePuppetProvisioner/lib/genericexec"
 	"github.com/mbaynton/SimplePuppetProvisioner/lib/puppetconfig"
@@ -19,6 +19,7 @@ type AppConfig struct {
 	BindAddress      string
 	LogFile          string
 	HttpAuth         *HttpAuthConfig
+	ProvisionAuth    *HttpAuthConfig
 	PuppetExecutable string
 	PuppetConfDir    string
 	PuppetConfig     *puppetconfig.PuppetConfig
@@ -27,7 +28,7 @@ type AppConfig struct {
 
 	Notifications []*NotificationsConfig
 	Log           *log.Logger
-	logBuffer     *bufio.Writer
+	logBuffer     *RingLog
 }
 
 type HttpAuthConfig struct {
@@ -41,6 +42,18 @@ type NotificationsConfig struct {
 	IrcConfig  *irc.Config
 	SlackToken *string
 	Webhooks   []string
+}
+
+type RingLog struct {
+	out  io.Writer
+	ring *ring.Ring
+}
+
+func (logBuffer *RingLog) Write(p []byte) (n int, err error) {
+	n, err = logBuffer.out.Write(p)
+	logBuffer.ring.Value = string(p)
+	logBuffer.ring = logBuffer.ring.Next()
+	return n, err
 }
 
 func LoadTheConfig(configName string, configPaths []string) AppConfig {
@@ -81,12 +94,17 @@ func LoadTheConfig(configName string, configPaths []string) AppConfig {
 }
 
 func (ctx *AppConfig) setDefaults() {
-	if ctx.HttpAuth != nil && ctx.HttpAuth.Realm == "" {
-		hostname, err := os.Hostname()
-		if err == nil {
-			ctx.HttpAuth.Realm = hostname
-		} else {
-			ctx.HttpAuth.Realm = "[realm not configured]"
+	if ctx.ProvisionAuth == nil {
+		ctx.ProvisionAuth = ctx.HttpAuth
+	}
+	for _, authConfig := range []*HttpAuthConfig{ctx.HttpAuth, ctx.ProvisionAuth} {
+		if authConfig != nil && authConfig.Realm == "" {
+			hostname, err := os.Hostname()
+			if err == nil {
+				authConfig.Realm = hostname
+			} else {
+				authConfig.Realm = "[realm not configured]"
+			}
 		}
 	}
 
@@ -110,7 +128,13 @@ func (ctx *AppConfig) setDefaults() {
 }
 
 func (ctx *AppConfig) establishLogger() {
-	ctx.Log = log.New(os.Stdout, "", log.LstdFlags)
+	r := ring.New(50)
+	for i := 0; i < r.Len(); i++ {
+		r.Value = ""
+		r = r.Next()
+	}
+	ctx.logBuffer = &RingLog{ring: r, out: os.Stdout}
+	ctx.Log = log.New(ctx.logBuffer, "", log.LstdFlags)
 }
 
 func (ctx *AppConfig) MoveLoggingToFile() {
@@ -122,9 +146,6 @@ func (ctx *AppConfig) MoveLoggingToFile() {
 			fmt.Errorf("Unable to create or open logfile: %s\n", err.Error())
 			os.Exit(1)
 		}
-		// Using a buffer seems like it might theoretically offer performance benefits, but would require a synchronized goroutine to flush it regularly.
-		//ctx.logBuffer = bufio.NewWriter(fileOutput)
-		//logOutput = ctx.logBuffer
 		logOutput = fileOutput
 		newLocation = ctx.LogFile
 	} else {
@@ -133,12 +154,6 @@ func (ctx *AppConfig) MoveLoggingToFile() {
 		newLocation = "a black hole (log location not configured.)"
 	}
 	ctx.Log.Printf("This log is moving to %s", newLocation)
-	ctx.Log.SetOutput(logOutput)
+	ctx.logBuffer.out = logOutput
 	ctx.Log.Printf("--- continuation of logging that began on stdout ---")
-}
-
-func (ctx *AppConfig) FlushLog() {
-	if ctx.logBuffer != nil {
-		ctx.logBuffer.Flush()
-	}
 }

--- a/lib/AppConfig.go
+++ b/lib/AppConfig.go
@@ -40,6 +40,7 @@ type NotificationsConfig struct {
 	Type       string
 	IrcConfig  *irc.Config
 	SlackToken *string
+	Webhooks   []string
 }
 
 func LoadTheConfig(configName string, configPaths []string) AppConfig {

--- a/lib/HttpProtectionMiddlewareFactory.go
+++ b/lib/HttpProtectionMiddlewareFactory.go
@@ -10,20 +10,20 @@ import (
 )
 
 type HttpProtectionMiddlewareFactory struct {
-	config *AppConfig
+	config *HttpAuthConfig
 
 	protectingMiddleware http.Handler
 	protectedHandler     http.Handler
 }
 
-func NewHttpProtectionMiddlewareFactory(config AppConfig) HttpProtectionMiddlewareFactory {
+func NewHttpProtectionMiddlewareFactory(config *HttpAuthConfig) HttpProtectionMiddlewareFactory {
 	handler := new(HttpProtectionMiddlewareFactory)
-	handler.config = &config
+	handler.config = config
 	return *handler
 }
 
 func (ctx *HttpProtectionMiddlewareFactory) WrapInProtectionMiddleware(nestedHandler http.Handler) http.Handler {
-	authConfig := ctx.config.HttpAuth
+	authConfig := ctx.config
 	if authConfig == nil { // No authentication required.
 		return nestedHandler
 	} else {

--- a/lib/HttpProtectionMiddlewareFactory_test.go
+++ b/lib/HttpProtectionMiddlewareFactory_test.go
@@ -9,19 +9,43 @@ import (
 
 func TestInvalidHttpAuthTypePanics(t *testing.T) {
 	appConfig := LoadTheConfig("InvalidAuthType.conf", []string{"../TestFixtures/configs"})
-	sut := NewHttpProtectionMiddlewareFactory(appConfig)
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.HttpAuth)
 	expectMiddlewareThrows(sut, t, "Configuration error: HttpAuth Type \"foo\" is unsupported.\n")
 }
 
 func TestMissingAuthDbFilePanics(t *testing.T) {
 	appConfig := LoadTheConfig("InvalidDbFile.conf", []string{"../TestFixtures/configs"})
-	sut := NewHttpProtectionMiddlewareFactory(appConfig)
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.HttpAuth)
 	expectMiddlewareThrows(sut, t, "stat /dev/notafile: no such file or directory")
 }
 
 func TestValidAuthConfigResultsInAuthenticationRequired(t *testing.T) {
 	appConfig := LoadTheConfig("NoRealm.conf", []string{"../TestFixtures/configs"})
-	sut := NewHttpProtectionMiddlewareFactory(appConfig)
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.HttpAuth)
+	var called = false
+	testHandler := func(response http.ResponseWriter, request *http.Request) {
+		called = true
+	}
+	protectedHandler := sut.WrapInProtectionMiddleware(http.HandlerFunc(testHandler))
+
+	testRequest, _ := http.NewRequest("POST", "http://0.0.0.0/", strings.NewReader(""))
+	monitor := httptest.NewRecorder()
+	protectedHandler.ServeHTTP(monitor, testRequest)
+	if monitor.Code != 401 || called == true {
+		t.Errorf("Authorization-protected request did not get protected by middleware (HTTP %d).\n", monitor.Code)
+	}
+}
+
+func TestProvisionAuthDefaultsToHttpAuth(t *testing.T) {
+	appConfig := LoadTheConfig("NoRealm.conf", []string{"../TestFixtures/configs"})
+	if appConfig.ProvisionAuth != appConfig.HttpAuth {
+		t.Errorf("ProvisionAuth did not default to HttpAuth parameters.\n")
+	}
+}
+
+func TestValidProvisionAuthResultsInAuthenticationRequired(t *testing.T) {
+	appConfig := LoadTheConfig("ProvisionAuth.conf", []string{"../TestFixtures/configs"})
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.ProvisionAuth)
 	var called = false
 	testHandler := func(response http.ResponseWriter, request *http.Request) {
 		called = true
@@ -38,7 +62,7 @@ func TestValidAuthConfigResultsInAuthenticationRequired(t *testing.T) {
 
 func TestNoAuthConfigResultsInNoAuthenticationRequired(t *testing.T) {
 	appConfig := LoadTheConfig("NoAuth.conf", []string{"../TestFixtures/configs"})
-	sut := NewHttpProtectionMiddlewareFactory(appConfig)
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.HttpAuth)
 	var called = false
 	testHandler := func(response http.ResponseWriter, request *http.Request) {
 		called = true
@@ -55,7 +79,7 @@ func TestNoAuthConfigResultsInNoAuthenticationRequired(t *testing.T) {
 
 func TestValidAuthResultsInProperlyServedResponse(t *testing.T) {
 	appConfig := LoadTheConfig("NoRealm.conf", []string{"../TestFixtures/configs"})
-	sut := NewHttpProtectionMiddlewareFactory(appConfig)
+	sut := NewHttpProtectionMiddlewareFactory(appConfig.HttpAuth)
 	var called = false
 	testHandler := func(response http.ResponseWriter, request *http.Request) {
 		called = true

--- a/spp.conf.yml
+++ b/spp.conf.yml
@@ -2,10 +2,16 @@
 BindAddress: 127.0.0.1:8240
 LogFile: /tmp/spp.log
 
+# Global HTTP authentication setting
 # HttpAuth:
 #   Type: basic # digest also supported.
 #   Realm: puppet.my.org
 #   DbFile: /path/to/.htpasswd # Consider the htpasswd or htdigest utilities
+
+# Provision API authentication setting - will default to HttpAuth values if not defined
+# ProvisionAuth:
+#   Type: basic
+#   DbFile: htpasswd
 
 PuppetExecutable: /opt/puppetlabs/bin/puppet
 
@@ -66,3 +72,6 @@ Notifications:
       Channels: "#iopsdev"
       Nick: PuppetBot
       Password: ""
+   - Type: gchat
+     Webhooks:
+        - 'https://chat.googleapis.com/v1/spaces/xxxxxxxxxxx/messages?key=xxxxx&token=xxxxx'


### PR DESCRIPTION
These commits add several features:

Support for Google Hangouts Chat webhooks
Separate HTTP auth config for the provision API
Web-based log file (/log shows last 50 log messages)